### PR TITLE
Add Ancestry/Relatedness component for SiteQC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/BH/BH
 RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/dplyr/dplyr_0.8.5.tar.gz', repos=NULL, type='source')"
 RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.12.8.tar.gz', repos=NULL, type='source')"
 RUN R -e "install.packages('https://cran.r-project.org/src/contrib/magrittr_1.5.tar.gz', repos=NULL, type='source')"
+RUN R -e "withr::with_makevars(c(PKG_LIBS = '-liconv'), install.packages('tidyverse',repos='http://cran.us.r-project.org'), assignment = '+=')"
+RUN R -e "install.packages('randomForest',repos='http://cran.us.r-project.org')"
 
 # Dump the details of the installed packages to a file for posterity
 RUN conda env export --name nf-core-siteqc-1.0dev > nf-core-siteqc-1.0dev.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/strin
 RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/plyr/plyr_1.8.5.tar.gz', repos=NULL, type='source')"
 RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/reshape2/reshape2_1.4.3.tar.gz', repos=NULL, type='source')"
 RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/tidyr/tidyr_1.0.2.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/BH/BH_1.72.0-2.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/dplyr/dplyr_0.8.5.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/data.table/data.table_1.12.8.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/magrittr_1.5.tar.gz', repos=NULL, type='source')"
 
 # Dump the details of the installed packages to a file for posterity
 RUN conda env export --name nf-core-siteqc-1.0dev > nf-core-siteqc-1.0dev.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,16 @@ RUN conda env create --quiet -f /environment.yml && conda clean -a
 # Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/siteqc-1.0dev/bin:$PATH
 
+# Install stringi R package and the ones that depend on it.
+# (Issue with stringi package from conda that it depends on libicu64 that
+# is not available for Debian 10)
+
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/stringi/stringi_1.4.5.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/stringr/stringr_1.3.1.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/plyr/plyr_1.8.5.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/reshape2/reshape2_1.4.3.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/tidyr/tidyr_1.0.2.tar.gz', repos=NULL, type='source')"
+
 # Dump the details of the installed packages to a file for posterity
 RUN conda env export --name nf-core-siteqc-1.0dev > nf-core-siteqc-1.0dev.yml
 
@@ -23,5 +33,4 @@ RUN touch .Renviron
 # Install GAWK
 RUN apt-get update && \
     apt-get install -y \
-                   gawk
-
+                   gawk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM nfcore/base:1.10.2
+FROM nfcore/base@sha256:2043dea2e3215a32576e2e9fa957d8d41f439d209abbf1f858fd02829d2b7d64
+#FROM nfcore/base:1.10.2
+
 LABEL authors="Christina Chatzipantsiou" \
       description="Docker image containing all software requirements for the siteqc pipeline"
+
 
 # Install the conda environment
 COPY environment.yml /
@@ -15,3 +18,10 @@ RUN conda env export --name nf-core-siteqc-1.0dev > nf-core-siteqc-1.0dev.yml
 # Instruct R processes to use these empty files instead of clashing with a local version
 RUN touch .Rprofile
 RUN touch .Renviron
+
+
+# Install GAWK
+RUN apt-get update && \
+    apt-get install -y \
+                   gawk
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,4 @@ RUN touch .Renviron
 RUN apt-get update && \
     apt-get install -y \
                    gawk \
+                   tabix \

--- a/bin/mendelerror_family_plotting.R
+++ b/bin/mendelerror_family_plotting.R
@@ -1,0 +1,76 @@
+#!/usr/bin/env Rscript
+
+library(data.table)
+library(magrittr)
+library(ggplot2)
+library(dplyr)
+library(reshape2)
+library(tidyr)
+library(stringr)
+
+args <- commandArgs(trailingOnly = T)
+
+options(bitmaptype="cairo")
+indir <- list.files(path = args[1],
+                    pattern = '*.fmendel',
+                    full.names = T)
+outfile <- file.path(args[1], 'SD_mendel_family.png')
+fmendel <- lapply(indir, fread) 
+fmendel %<>% 
+  bind_rows() %>% 
+  as_tibble() %>%
+  group_by(FID, PAT, MAT, CHLD) %>%
+  summarise(N=sum(N))
+
+
+#Plot distribution
+summary(fmendel$N) %>%
+  write.csv(file.path(args[1], 'FamilyWise.summarystats'),
+            row.names = F)
+
+sdv <- 4*sd(fmendel$N, na.rm = T)
+mn <- mean(fmendel$N, na.rm = T)
+
+fmendel %>% 
+  filter(N < mn+sdv & N > mn+(-1*sdv)) %>%
+  ungroup() %>%
+  select(FID) %>%
+  distinct() %>%
+    write.csv(file.path(args[1],'MendelFamilies_4SD.fam'),
+            row.names = F,
+            quote = F)
+md <- median(fmendel$N, na.rm = T)
+sd <- sd(fmendel$N)
+png(filename = outfile, 
+    width = 6, height = 6,
+    units = 'in', res = 300)
+fmendel %>% ggplot(aes(N)) +
+  geom_density(fill = 'grey35', alpha = 0.7) + 
+  geom_vline(xintercept = mn,
+             linetype = 'dashed',
+             colour = "#29c440") +
+  geom_vline(xintercept = md,
+             linetype = 'dashed',
+             colour = "#29c48b") +
+  geom_vline(xintercept = sd*2,
+           linetype = 'dotted',
+           colour = "#a4dd29") +
+  geom_vline(xintercept = sd*-2,
+             linetype = 'dotted',
+             colour = "#a4dd29") +
+  geom_vline(xintercept = sd*3,
+             linetype = 'dotted',
+             colour = "#dd8329") +
+  geom_vline(xintercept = sd*-3,
+           linetype = 'dotted',
+           colour = "#dd8329") +
+  geom_vline(xintercept = sd*4,
+             linetype = 'dotted',
+             colour = "#dd4a29") +
+  geom_vline(xintercept = sd*-4,
+             linetype = 'dotted',
+             colour = "#dd4a29")
+dev.off()
+
+
+### END ###

--- a/bin/mendelerror_family_plotting.R
+++ b/bin/mendelerror_family_plotting.R
@@ -25,8 +25,7 @@ fmendel %<>%
 
 #Plot distribution
 summary(fmendel$N) %>%
-  write.csv(file.path(args[1], 'FamilyWise.summarystats'),
-            row.names = F)
+  capture.output(file=file.path(args[1], 'FamilyWise.summarystats'))
 
 sdv <- 4*sd(fmendel$N, na.rm = T)
 mn <- mean(fmendel$N, na.rm = T)

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -32,6 +32,9 @@ params {
   xx_sample_ids = 's3://lifebit-featured-datasets/projects/gel/siteqc/xx.txt'
   xy_sample_ids = 's3://lifebit-featured-datasets/projects/gel/siteqc/xy.txt'
   triodata_keep_pheno = 's3://lifebit-featured-datasets/projects/gel/siteqc/nodata'
+  triodata_fam = 's3://lifebit-featured-datasets/projects/gel/siteqc/example.fam'
+  s3_path_1kg_start = 's3://1000genomes/release/20130502/ALL.'
+  s3_path_1kg_end = '.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'
  
   // Values
   query_format_start = '%CHROM %POS %REF %ALT\n'
@@ -55,10 +58,11 @@ params {
   awk_expr_miss1 = 'BEGIN{FS=" "} {print $1" "NF-1}'
   awk_expr_miss2 = 'BEGIN{FS=" "} {print $1" "NF-1}'
   awk_expr_ab_ratio_1 = '{print $1"\t"NF -1}'
+  awk_expr_pull_1kg_p3_sites = '/^##/ {next} { print $1"\t"$2"\t"$4"\t"$5}'
   mend_err_p1_rset_missing_var_ids = '@:#,\\\$r,\\\$a'
   mend_err_p1_vcf_half_call = 'm'
   mend_err_p1_new_id_max_allele_len = '60 missing'
-  triodata_fam = 's3://lifebit-featured-datasets/projects/gel/siteqc/example.fam'
+
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -31,7 +31,8 @@ params {
   input = 's3://lifebit-featured-datasets/projects/gel/siteqc/input.csv'
   xx_sample_ids = 's3://lifebit-featured-datasets/projects/gel/siteqc/xx.txt'
   xy_sample_ids = 's3://lifebit-featured-datasets/projects/gel/siteqc/xy.txt'
-  
+  triodata_keep_pheno = 's3://lifebit-featured-datasets/projects/gel/siteqc/nodata'
+ 
   // Values
   query_format_start = '%CHROM %POS %REF %ALT\n'
   query_format_miss1 = '%CHROM:%POS-%REF/%ALT [%GT ] \n' 

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -58,6 +58,7 @@ params {
   mend_err_p1_rset_missing_var_ids = '@:#,\\\$r,\\\$a'
   mend_err_p1_vcf_half_call = 'm'
   mend_err_p1_new_id_max_allele_len = '60 missing'
+  triodata_fam = 's3://lifebit-featured-datasets/projects/gel/siteqc/example.fam'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -54,6 +54,9 @@ params {
   awk_expr_miss1 = 'BEGIN{FS=" "} {print $1" "NF-1}'
   awk_expr_miss2 = 'BEGIN{FS=" "} {print $1" "NF-1}'
   awk_expr_ab_ratio_1 = '{print $1"\t"NF -1}'
+  mend_err_p1_rset_missing_var_ids = '@:#,\\\$r,\\\$a'
+  mend_err_p1_vcf_half_call = 'm'
+  mend_err_p1_new_id_max_allele_len = '60 missing'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,7 @@ dependencies:
   - vcftools=0.1.15
   - bcftools=1.10.2
   - plink=1.90b6.12
+  - conda-forge:r-data.table=1.12.8
+  - conda-forge:r-magrittr=1.5
+  - conda-forge:r-ggplot2=3.3.0
+  - conda-forge:r-dplyr=0.8.5

--- a/main.nf
+++ b/main.nf
@@ -130,7 +130,8 @@ ch_bcfs_med_cov_non_miss,
 ch_bcfs_median_gq,
 ch_bcfs_ab_ratio_p1,
 ch_bcfs_ab_ratio_p2,
-ch_bcfs_pull_ac) = ch_bcfs.into(10)
+ch_bcfs_pull_ac,
+ch_bcfs_mend_err_p1) = ch_bcfs.into(11)
 
 // List with sample ids to include/exclude
 ch_xy_sample_id_files = Channel.fromPath(params.xy_sample_ids, checkIfExists: true)
@@ -495,32 +496,32 @@ process pull_ac {
 //     """
 // }
 
-//  /*
-//  * STEP - mend_err_p1: Create a bed file for the mendel error calcs
-//  */
-// process mend_err_p1 {
-//     publishDir "${params.outdir}/", mode: params.publish_dir_mode
+  /*
+  * STEP - mend_err_p1: Create a bed file for the mendel error calcs
+  */
+ process mend_err_p1 {
+     publishDir "${params.outdir}/MendelErr/", mode: params.publish_dir_mode
+     container = "lifebitai/plink2"
 
-//     input:
-//     file sample_bcf from ch_files_bcf
+     input:
+     set val(region), file(bcf), file(index) from ch_bcfs_mend_err_p1 
 
-//     output:
-//     file "*BED_trio_*" into ch_files_txt
+     output:
+     file "*BED_trio_*" into ch_mend_err_p1_plink_files
 
-//     script:
-//     """
-//     plink2 --bcf ${bcf} \
-//     --keep $triodata.keep \
-//     --make-bed \
-//     --vcf-half-call m \
-//     --set-missing-var-ids @:#,\$r,\$a \
-//     --new-id-max-allele-len 60 missing\
-//     --double-id \
-//     --real-ref-alleles \
-//     --allow-extra-chr \
-//     --out ${out}MendelErr/BED_trio_${i}
-//     """
-// }
+     script:
+     """
+     plink2 --bcf ${bcf} \
+     --make-bed \
+     --set-missing-var-ids ${params.mend_err_p1_rset_missing_var_ids} \
+     --vcf-half-call ${params.mend_err_p1_vcf_half_call} \
+     --new-id-max-allele-len ${params.mend_err_p1_new_id_max_allele_len} \
+     --double-id \
+     --real-ref-alleles \
+     --allow-extra-chr \
+     --out BED_trio_${region}
+     """
+ }
 
 // /*
 //  * STEP - mend_err_p2: Calculate mendelian errors

--- a/main.nf
+++ b/main.nf
@@ -577,7 +577,7 @@ process mend_err_p2 {
  * STEP - mend_dist: Summary stats and good families for Mendel errors
  */
 process mend_dist {
-    publishDir "${params.outdir}/", mode: params.publish_dir_mode
+    publishDir "${params.outdir}/Mend_dist/", mode: params.publish_dir_mode
 
     input:
     file (fmendel) from ch_mend_err_p2_plink_files.collect()

--- a/main.nf
+++ b/main.nf
@@ -319,106 +319,106 @@ process complete_sites {
  * STEP - median_coverage_all: Produce median value for depth across all GT
  */
 
-// process median_coverage_all {
-//     publishDir "${params.outdir}/median_coverage_all/", mode: params.publish_dir_mode
+ process median_coverage_all {
+     publishDir "${params.outdir}/median_coverage_all/", mode: params.publish_dir_mode
 
-//     input:
-//     set val(region), file(bcf), file(index) from ch_bcfs_med_cov_all
-//     each file(xy_sample_ids) from ch_xy_sample_id_med_cov_all
-//     each file(xx_sample_ids) from ch_xx_sample_id_med_cov_all
+     input:
+     set val(region), file(bcf), file(index) from ch_bcfs_med_cov_all
+     each file(xy_sample_ids) from ch_xy_sample_id_med_cov_all
+     each file(xx_sample_ids) from ch_xx_sample_id_med_cov_all
 
-//     output:
-//     file "medianCoverageAll*" into ch_outputs_med_cov_all
+     output:
+     file "medianCoverageAll*" into ch_outputs_med_cov_all
 
-//     script:
-//     """
-//     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
-//         bcftools query ${bcf} -f '${query_format_med_cov_all}' -S ${xy_sample_ids} | awk '${awk_expr_med_cov_all}' > medianCoverageAll${region}_XY
-//         bcftools query ${bcf} -f '${query_format_med_cov_all}' -S ${xy_sample_ids} | awk '${awk_expr_med_cov_all}' > medianCoverageAll${region}_XX 
-//     else
-//         bcftools query ${bcf} -f '${query_format_med_cov_all}'| awk '${awk_expr_med_cov_all}' > medianCoverageAll${region}
-//     fi
-//     """
-//  }
+     script:
+     """
+     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
+         bcftools query ${bcf} -f '${query_format_med_cov_all}' -S ${xy_sample_ids} | awk '${awk_expr_med_cov_all}' > medianCoverageAll${region}_XY
+         bcftools query ${bcf} -f '${query_format_med_cov_all}' -S ${xy_sample_ids} | awk '${awk_expr_med_cov_all}' > medianCoverageAll${region}_XX 
+     else
+         bcftools query ${bcf} -f '${query_format_med_cov_all}'| awk '${awk_expr_med_cov_all}' > medianCoverageAll${region}
+     fi
+     """
+  }
 
 //  /*
 //  * STEP - median_coverage_non_miss: Median coverage for fully present genotypes
 //  */
 
-// process median_coverage_non_miss {
-//     publishDir "${params.outdir}/medianCoverageNonMiss/", mode: params.publish_dir_mode
+ process median_coverage_non_miss {
+     publishDir "${params.outdir}/medianCoverageNonMiss/", mode: params.publish_dir_mode
 
-//     input:
-//     set val(region), file(bcf), file(index) from ch_bcfs_med_cov_non_miss
-//     each file(xy_sample_ids) from ch_xy_sample_id_med_cov_non_miss
-//     each file(xx_sample_ids) from ch_xx_sample_id_med_cov_non_miss
+     input:
+     set val(region), file(bcf), file(index) from ch_bcfs_med_cov_non_miss
+     each file(xy_sample_ids) from ch_xy_sample_id_med_cov_non_miss
+     each file(xx_sample_ids) from ch_xx_sample_id_med_cov_non_miss
 
-//     output:
-//     file "medianNonMiss_depth_*" into ch_outputs_med_cov_nonmiss
+     output:
+     file "medianNonMiss_depth_*" into ch_outputs_med_cov_nonmiss
 
-//     script:
+     script:
 
-//     """
-//     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
-//         bcftools query ${bcf} -f '${query_format_med_cov_nonmisss}' -e '${query_exclude_med_cov_nonmiss}' -S ${xy_sample_ids} | awk '${awk_expr_med_cov_nonmiss}' > medianNonMiss_depth_${region}_XY
-//         bcftools query ${bcf} -f '${query_format_med_cov_nonmisss}' -e '${query_exclude_med_cov_nonmiss}' -S ${xx_sample_ids} | awk '${awk_expr_med_cov_nonmiss}' > medianNonMiss_depth_${region}_XX
-//     else
-//         bcftools query ${bcf} -f '${query_format_med_cov_nonmisss}' -e '${query_exclude_med_cov_nonmiss}' | awk '${awk_expr_med_cov_nonmiss}' > medianNonMiss_depth_${region}
-//     fi
-//     """
-//  }
+     """
+     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
+         bcftools query ${bcf} -f '${query_format_med_cov_nonmisss}' -e '${query_exclude_med_cov_nonmiss}' -S ${xy_sample_ids} | awk '${awk_expr_med_cov_nonmiss}' > medianNonMiss_depth_${region}_XY
+         bcftools query ${bcf} -f '${query_format_med_cov_nonmisss}' -e '${query_exclude_med_cov_nonmiss}' -S ${xx_sample_ids} | awk '${awk_expr_med_cov_nonmiss}' > medianNonMiss_depth_${region}_XX
+     else
+         bcftools query ${bcf} -f '${query_format_med_cov_nonmisss}' -e '${query_exclude_med_cov_nonmiss}' | awk '${awk_expr_med_cov_nonmiss}' > medianNonMiss_depth_${region}
+     fi
+     """
+  }
 
 //  /*
 //  * STEP - median_gq: Calculate median GQ
 //  */
-// process median_gq {
-//     publishDir "${params.outdir}/medianGQ", mode: params.publish_dir_mode
+ process median_gq {
+     publishDir "${params.outdir}/medianGQ", mode: params.publish_dir_mode
 
-//     input:
-//     set val(region), file(bcf), file(index) from ch_bcfs_median_gq
-//     each file(xy_sample_ids) from ch_xy_sample_id_median_gq
-//     each file(xx_sample_ids) from ch_xx_sample_id_median_gq
+     input:
+     set val(region), file(bcf), file(index) from ch_bcfs_median_gq
+     each file(xy_sample_ids) from ch_xy_sample_id_median_gq
+     each file(xx_sample_ids) from ch_xx_sample_id_median_gq
 
-//     output:
-//     file "medianGQ_*" into ch_outputs_median_gq
+     output:
+     file "medianGQ_*" into ch_outputs_median_gq
 
-//     script:
-//     """
-//     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
-//         bcftools query ${bcf} -f '${query_format_median_gq}' -e '${query_exclude_median_gq}' -S ${xy_sample_ids} | awk '${awk_expr_median_gq}'  > medianGQ_${region}_XY
-//         bcftools query ${bcf} -f '${query_format_median_gq}' -e '${query_exclude_median_gq}' -S ${xx_sample_ids} | awk '${awk_expr_median_gq}'  > medianGQ_${region}_XX
-//     else
-//         bcftools query ${bcf} -f '${query_format_median_gq}' -e '${query_exclude_median_gq}' | awk '${awk_expr_median_gq}'  > medianGQ_${region}
-//     fi    
-//     """
-//  }
+     script:
+     """
+     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
+         bcftools query ${bcf} -f '${query_format_median_gq}' -e '${query_exclude_median_gq}' -S ${xy_sample_ids} | awk '${awk_expr_median_gq}'  > medianGQ_${region}_XY
+         bcftools query ${bcf} -f '${query_format_median_gq}' -e '${query_exclude_median_gq}' -S ${xx_sample_ids} | awk '${awk_expr_median_gq}'  > medianGQ_${region}_XX
+     else
+         bcftools query ${bcf} -f '${query_format_median_gq}' -e '${query_exclude_median_gq}' | awk '${awk_expr_median_gq}'  > medianGQ_${region}
+     fi
+     """
+  }
 
 //  /*
 //  * STEP - ab_ratio_p1: AB ratio calculation - number of hets passing binomial test (reads supporting het call)
 //  */
 
-// process ab_ratio_p1 {
-//     publishDir "${params.outdir}/AB_hetPass/", mode: params.publish_dir_mode
+ process ab_ratio_p1 {
+     publishDir "${params.outdir}/AB_hetPass/", mode: params.publish_dir_mode
 
-//     input:
-//     set val(region), file(bcf), file(index) from ch_bcfs_ab_ratio_p1
-//     each file(xy_sample_ids) from ch_xy_sample_id_ab_ratio_p1
-//     each file(xx_sample_ids) from ch_xx_sample_id_ab_ratio_p1
+     input:
+     set val(region), file(bcf), file(index) from ch_bcfs_ab_ratio_p1
+     each file(xy_sample_ids) from ch_xy_sample_id_ab_ratio_p1
+     each file(xx_sample_ids) from ch_xx_sample_id_ab_ratio_p1
 
-//     output:
-//     file "*N_hets_passed.txt" into ch_outputs_ab_ratio_p1
+     output:
+     file "hetPass_*" into ch_outputs_ab_ratio_p1
 
-//     script:
+     script:
 
-//     """
-//     #We only calculate AB ratio for XX
-//     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
-//         bcftools query ${bcf} -f '${query_format_ab_ratio_p1}' -S ${xx_sample_ids} -i '${query_include_ab_ratio_1}' | awk '${awk_expr_ab_ratio_1}' > hetPass_${region}_XX
-//     else
-//         bcftools query ${bcf} -f '${query_format_ab_ratio_p1}' -i ${query_include_ab_ratio_1} | awk '${awk_expr_ab_ratio_1}' > hetPass_${region}
-//     fi
-//     """
-//  }
+     """
+     #We only calculate AB ratio for XX
+     if [[ $region == *"chrX"* ]] || [[ $region == *"chrY"* ]] ; then
+         bcftools query ${bcf} -f '${query_format_ab_ratio_p1}' -S ${xx_sample_ids} -i '${query_include_ab_ratio_1}' | awk '${awk_expr_ab_ratio_1}' > hetPass_${region}_XX
+     else
+         bcftools query ${bcf} -f '${query_format_ab_ratio_p1}' -i '${query_include_ab_ratio_1}' | awk '${awk_expr_ab_ratio_1}' > hetPass_${region}
+     fi
+     """
+  }
 
 //  /*
 //  * STEP - ab_ratio_p2: Number of het GTs for p2 AB ratio
@@ -475,10 +475,10 @@ process pull_ac {
 // // TOCHECK: Ok to run once and provide as a resource?
 // process pull_1kg_p3_sites {
 //     publishDir "${params.outdir}/", mode: params.publish_dir_mode
-    
+
 //     input:
 //     file(1kg_vcfs_archive) from ch_1kg_vcfs_archive
-    
+
 //     output:
 //     file "tmp_1kgp${region}.txt" into ..
 

--- a/main.nf
+++ b/main.nf
@@ -570,24 +570,26 @@ process mend_err_p2 {
     """
 }
 
-// /*
-//  * STEP - mend_dist: Summary stats and good families for Mendel errors
-//  */
-// process mend_dist {
-//     publishDir "${params.outdir}/", mode: params.publish_dir_mode
+/*
+ * STEP - mend_dist: Summary stats and good families for Mendel errors
+ */
+process mend_dist {
+    publishDir "${params.outdir}/", mode: params.publish_dir_mode
 
-//     input:
-//     file fmendel_file from ch_fmendel_files
+    input:
+    file (fmendel) from ch_mend_err_p2_plink_files.collect()
 
-//     output:
-//     file "*summary_stats.txt" into ch_files_txt
+    output:
+    file "FamilyWise.summarystats" into ch_mend_dist_out
+    file "MendelFamilies_4SD.fam" into ch_mend_keep_families
+    file "SD_mendel_family.png" into ch_mend_dist_out_plot
 
-//     script:
+    script:
 
-//     """
-//     mendelerror_family_plotting.R ${out}MendelErr
-//     """
-// }
+    """
+    mendelerror_family_plotting.R .
+    """
+}
 
 // /*
 //  * STEP - mend_err_p3: Calculate mendel errors on just good families

--- a/main.nf
+++ b/main.nf
@@ -155,6 +155,11 @@ ch_xx_sample_id_median_gq,
 ch_xx_sample_id_ab_ratio_p1,
 ch_xx_sample_id_ab_ratio_p2) = ch_xx_sample_id_files.into(8)
 
+// Plink files for mend_err_p* processes
+Channel
+  .fromPath(params.triodata_keep_pheno)
+  .set {ch_triodata_keep_pheno} 
+
 // Header log info
 log.info nfcoreHeader()
 def summary = [:]
@@ -505,11 +510,13 @@ process pull_ac {
 
      input:
      set val(region), file(bcf), file(index) from ch_bcfs_mend_err_p1 
+     each file(triodata_keep_file) from ch_triodata_keep_pheno
 
      output:
      file "*BED_trio_*" into ch_mend_err_p1_plink_files
 
      script:
+     optional_keep_argument = params.triodata_keep_pheno != "s3://lifebit-featured-datasets/projects/gel/siteqc/nodata" ? "--keep ${triodata_keep_file}" : ""
      """
      plink2 --bcf ${bcf} \
      --make-bed \
@@ -519,7 +526,8 @@ process pull_ac {
      --double-id \
      --real-ref-alleles \
      --allow-extra-chr \
-     --out BED_trio_${region}
+     --out BED_trio_${region} \
+     ${optional_keep_argument}
      """
  }
 

--- a/main.nf
+++ b/main.nf
@@ -33,11 +33,11 @@ def helpMessage() {
 
 
     Options:
-      --query_format_start [str]      Bcftools query format used for creating the skeleton of the sites.
-      --query_format_miss1 [str]      Bcftools query format used for the missingeness 1 step.
+      
+      
     
     References                        If not specified in the configuration file or you wish to overwrite any of the references
-      --fasta [file]                  Path to fasta reference
+      
 
     Other options:
       --outdir [file]                 The output directory where the results will be saved
@@ -100,9 +100,9 @@ query_format_miss1 = params.query_format_miss1
                         .ifEmpty { exit 1, "Input file with samples and platekeys data not found at ${params.inputFinalPlatekeys}. Is the file path correct?" }
                         .set { ch_inputFinalPlatekeys }
 
-  Channel.fromPath(params.inputMichiganLDfile)
-                        .ifEmpty { exit 1, "Input file with Michigan LD data not found at ${params.inputMichiganLDfile}. Is the file path correct?" }
-                        .set { ch_inputMichiganLDfile }
+  
+  
+  
   Channel.fromPath(params.inputPCsancestryrelated)
                         .ifEmpty { exit 1, "Input file with Michigan LD data not found at ${params.inputPCsancestryrelated}. Is the file path correct?" }
                         .set { ch_inputPCsancestryrelated }
@@ -213,7 +213,7 @@ process further_filtering {
 
     input:
     set val(region), file(bcf_filtered) from ch_regions_filtered
-    file (michiganld_exclude_regions_file) from ch_inputMichiganLDfile
+    
     output:
     set val(region), file("MichiganLD_regionsFiltered_${region}.bcf"), file("MAF_filtered_1kp3intersect_${region}.txt") into ch_further_filtering
 

--- a/main.nf
+++ b/main.nf
@@ -554,7 +554,7 @@ process mend_err_p2 {
     publishDir "${params.outdir}/MendelErr/", mode: params.publish_dir_mode
 
     input:
-    file predefined_fam from ch_mend_err_p2_fam
+    each file(predefined_fam) from ch_mend_err_p2_fam
     tuple val(region), file(bed), file(bim), file(fam), file(log) from ch_mend_err_p1_plink_files
 
     output:

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,7 @@ manifest {
 
 // Global default params, used in configs
 params {
-
+ container = 'lifebitai/siteqc:1.0dev'
   // Workflow flags
   outdir = 'results'
   publish_dir_mode = 'copy'


### PR DESCRIPTION
To test the pipeline do as follows (In ec2 instance):

1.- If not done yet install all standard dependencies for nextflow
sudo yum install -y tree openssl openssl-devel gcc-c++ tmux python34-pip htop graphviz&& curl -s https://get.nextflow.io | bash && sudo mv /home/ec2-user/nextflow /bin/ && pip-3.4 install awscli --upgrade –user

2.- Clone the repo for this
git clone https://github.com/lifebit-ai/siteqc.git

3.- Checkout to my branch
cd siteqc/
git checkout salvador-siteqc-dev1

4.- Build the container locally (its not yet pushed with its modifications to dockerhub)
docker build -t lifebitai/siteqc:1.0dev . -f Dockerfile

5.- Run the pipeline with its required inputs:

nextflow main.nf --inputDir 's3://lifebit-featured-datasets/projects/gel/siteqc/ARtestFiles/Annotation_newtest/' --input s3://lifebit-featured-datasets/projects/gel/siteqc/input.csv --inputMichiganLDfile s3://lifebit-featured-datasets/projects/gel/siteqc/MichiganLD_liftover_exclude_regions_PARSED.txt --inputMichiganLDfileExclude s3://lifebit-featured-datasets/projects/gel/siteqc/MichiganLD_liftover_exclude_regions_PARSED.txt --inputAncestryAssignmentProbs s3://lifebit-featured-datasets/projects/gel/siteqc/aggV2_R9_M30K_1KGP3_ancestry_assignment_probs.tsv --inputPCsancestryrelated s3://lifebit-featured-datasets/projects/gel/siteqc/aggV2_bedmerge_30KSNPs_labkeyV9_08062020_update_PCsancestryrelated.tsv --inputFinalPlatekeys s3://lifebit-featured-datasets/projects/gel/siteqc/sampleList.txt -with-dag DAG.png

It should run correctly as it did for me here and show a similar output:

![image](https://user-images.githubusercontent.com/9978265/92906619-3bd60500-f3ea-11ea-8e52-968dfdabbe13.png)


Currently the pipeline has the next mapping of files and processes according to the DAG shown by nextflow:
![image](https://user-images.githubusercontent.com/9978265/92906065-c9fdbb80-f3e9-11ea-8499-e4e86c5134ae.png)
