### PR TITLE
Fixes plink2 container issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.nextflow*
+work/
+data/
+results/
+.DS_Store
+tests/
+testing/
+*.pyc
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,15 @@ FROM nfcore/base@sha256:2043dea2e3215a32576e2e9fa957d8d41f439d209abbf1f858fd0282
 LABEL authors="Christina Chatzipantsiou, Vlad Dembrovskyi" \
       description="Docker image containing all software requirements for the siteqc pipeline"
 
+# Install GAWK and other needed tools
+RUN apt-get update && \
+    apt-get install -y \
+                   gawk \
+                   wget \
+                   zip \
+                   procps && \
+    rm -rf /var/lib/apt/lists/*
+
 
 # Install the conda environment
 COPY environment.yml /
@@ -29,8 +38,10 @@ RUN conda env export --name nf-core-siteqc-1.0dev > nf-core-siteqc-1.0dev.yml
 RUN touch .Rprofile
 RUN touch .Renviron
 
+# Install plink2 Alpha 2.3 Developmental (20 Oct 2020)
+# Correct version of Plink2 is not available on Conda
+RUN wget http://s3.amazonaws.com/plink2-assets/plink2_linux_x86_64_20201020.zip && \
+    unzip plink2_linux_x86_64_20201020.zip -d plink2 && \
+    rm plink2_linux_x86_64_20201020.zip
 
-# Install GAWK
-RUN apt-get update && \
-    apt-get install -y \
-                   gawk \
+ENV PATH /plink2:$PATH

--- a/main.nf
+++ b/main.nf
@@ -592,7 +592,6 @@ process pull_1kg_p3_sites {
   */
  process mend_err_p1 {
      publishDir "${params.outdir}/MendelErr/", mode: params.publish_dir_mode
-     container = "lifebitai/plink2@sha256:e0183ea08bf04e7ce36fa13e24daf3696232198c93a07c952cb0d0f3028966b9"
 
      input:
      set val(region), file(bcf), file(index) from ch_bcfs_mend_err_p1 

--- a/main.nf
+++ b/main.nf
@@ -592,7 +592,7 @@ process pull_1kg_p3_sites {
   */
  process mend_err_p1 {
      publishDir "${params.outdir}/MendelErr/", mode: params.publish_dir_mode
-     container = "lifebitai/plink2"
+     container = "lifebitai/plink2@sha256:e0183ea08bf04e7ce36fa13e24daf3696232198c93a07c952cb0d0f3028966b9"
 
      input:
      set val(region), file(bcf), file(index) from ch_bcfs_mend_err_p1 


### PR DESCRIPTION
### Description
The general [lifebitai/plink2](https://hub.docker.com/r/lifebitai/plink2/tags) container has been used for one of the processes. The container has been updated to version that is failing the pipeline.

Now the plink2 software with version that is not failing the process is included in main siteqc container, so the pipeline no longer depends on external containers and is self-contained.

The updated siteqc container is already pushed to Dockerhub.

### Test run with the latest container
```
git clone https://github.com/lifebit-ai/siteqc.git
cd siteqc
git checkout fixes-plink2-cntnr-ver
nextflow run main.nf --input s3://lifebit-featured-datasets/projects/gel/siteqc/input.csv
```
![image](https://user-images.githubusercontent.com/64809705/97434436-afdf5480-1927-11eb-9fdb-e17833e1340d.png)
